### PR TITLE
fix results overflow on large samples

### DIFF
--- a/css/components/_result.scss
+++ b/css/components/_result.scss
@@ -1,4 +1,6 @@
 .result {
+  max-width: 25rem;
+  max-height: 23rem;
   height: 100%;
   border: 1px solid rgba(0, 0, 0, 0.25);
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
@@ -18,6 +20,9 @@
   &__text {
     text-align: center;
     font-size: smaller;
+    word-break: break-all;
+    max-height: 15rem;
+    overflow-y: auto;
   }
 
   &__hero {

--- a/css/layouts/_responsiveness.scss
+++ b/css/layouts/_responsiveness.scss
@@ -1,5 +1,6 @@
 .even-columns {
   gap: 1.5rem;
+  grid-auto-columns: .975fr 1.1fr;
 }
 
 .container {

--- a/css/main.css
+++ b/css/main.css
@@ -62,6 +62,8 @@ section.results {
 }
 
 .result {
+  max-width: 25rem;
+  max-height: 23rem;
   height: 100%;
   border: 1px solid rgba(0, 0, 0, 0.25);
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
@@ -80,6 +82,9 @@ section.results {
 .result__text {
   text-align: center;
   font-size: smaller;
+  word-break: break-all;
+  max-height: 15rem;
+  overflow-y: auto;
 }
 .result__hero {
   margin-inline: auto;
@@ -92,6 +97,7 @@ section.results {
 
 .even-columns {
   gap: 1.5rem;
+  grid-auto-columns: 0.975fr 1.1fr;
 }
 
 .container {


### PR DESCRIPTION
# Fix results overflow on large samples
This fixes #4 

## Implementation
The implementation was made accordingly to the [Firefox Developer Docs MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break) the `word-break` style property does the job !
It's not required to lock the results `width` tho...

> `break-all`
> To prevent overflow, word breaks should be inserted between any two characters (excluding Chinese/Japanese/Korean text).
>
> #### Note: In contrast to word-break: break-word and overflow-wrap: break-word (see [overflow-wrap](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap)), word-break: break-all will create a break at the exact place where text would otherwise overflow its container (even if putting an entire word on its own line would negate the need for a break).
```css
word-break: break-all;
```

### Other Considerations xor Changes 
 - Modified the grid columns size
 - Modified the `max-width` & `max-height` on *results*.

### Compatibility scores it's about +96% ✔️ 