### PR TITLE
ci: add production build

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
     />
 
     <link rel="stylesheet" href="./css/main.css" />
-    <script src="./js/cipher.js" crossorigin="anonymous" defer="true"></script>
-    <script src="./js/main.js" crossorigin="anonymous" defer="true"></script>
+    <script src="./js/cipher.js" type="module" crossorigin="anonymous" defer="true"></script>
+    <script src="./js/main.js" type="module" crossorigin="anonymous" defer="true"></script>
   </head>
   <body>
     <!-- HEADER -->

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "vite": "^3.0.4"
   },
   "scripts": {
-    "dev": "yarn run sass -w . & yarn run vite"
+    "dev": "yarn run sass -w . & yarn run vite",
+    "build": "yarn vite build --base ./"
   },
   "name": "cipher",
   "version": "1.0.0",


### PR DESCRIPTION
# ci: add production build
Closes #1 .

## Overview
The production build script generates a compressed and polished version of the code inside the `dist` folder... if the folder is not present it will generate it, otherwise, it will overwrite it.

#### Usage:
`yarn run build` or `npm run build`

> ##### The dist folder has to be hosted to work  ([CORS Policies issue][mdn-cors]).
[mdn-cors]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS